### PR TITLE
Fixing Vector3 parsing error

### DIFF
--- a/Features/Extensions/StructExtensions.cs
+++ b/Features/Extensions/StructExtensions.cs
@@ -43,9 +43,9 @@ public static class StructExtensions
 		s = s.Trim('(', ')').Replace(" ", "");
 		string[] split = s.Split(',');
 
-		float x = float.Parse(split[0]);
-		float y = float.Parse(split[1]);
-		float z = float.Parse(split[2]);
+		float x = float.Parse(split[0], CultureInfo.InvariantCulture);
+		float y = float.Parse(split[1], CultureInfo.InvariantCulture);
+		float z = float.Parse(split[2], CultureInfo.InvariantCulture);
 
 		return new Vector3(x, y, z);
 	}


### PR DESCRIPTION
Fix on systems where a comma is used to separate floating point numbers. 

e.g (-10.500, 403.631, 60.810) would be parsed to  (-1050.00, 40363.00, 6081.00) because float.parse would search for a comma