### PR TITLE
WaitSystem

### DIFF
--- a/Events/Handlers/Internal/ActionOnEventHandlers.cs
+++ b/Events/Handlers/Internal/ActionOnEventHandlers.cs
@@ -13,53 +13,74 @@ public class ActionOnEventHandlers : CustomEventsHandler
 {
 	private static Config Config => ProjectMER.Singleton.Config!;
 
-	public override void OnServerWaitingForPlayers() => Timing.CallDelayed(0.1f, () => HandleActionList(Config.OnWaitingForPlayers));
-	public override void OnServerRoundStarted() => HandleActionList(Config.OnRoundStarted);
-	public override void OnServerLczDecontaminationStarted() => HandleActionList(Config.OnLczDecontaminationStarted);
-	public override void OnWarheadStarted(WarheadStartedEventArgs ev) => HandleActionList(Config.OnWarheadStarted);
-	public override void OnWarheadStopped(WarheadStoppedEventArgs ev) => HandleActionList(Config.OnWarheadStopped);
-	public override void OnWarheadDetonated(WarheadDetonatedEventArgs ev) => HandleActionList(Config.OnWarheadDetonated);
+	public override void OnServerWaitingForPlayers() => Timing.RunCoroutine(HandleActionList(Config.OnWaitingForPlayers));
+	public override void OnServerRoundStarted() => Timing.RunCoroutine(HandleActionList(Config.OnRoundStarted));
+	public override void OnServerLczDecontaminationStarted() => Timing.RunCoroutine(HandleActionList(Config.OnLczDecontaminationStarted));
+	public override void OnWarheadStarted(WarheadStartedEventArgs ev) => Timing.RunCoroutine(HandleActionList(Config.OnWarheadStarted));
+	public override void OnWarheadStopped(WarheadStoppedEventArgs ev) => Timing.RunCoroutine(HandleActionList(Config.OnWarheadStopped));
+	public override void OnWarheadDetonated(WarheadDetonatedEventArgs ev) => Timing.RunCoroutine(HandleActionList(Config.OnWarheadDetonated));
 
-	private void HandleActionList(List<string> list)
+	private IEnumerator<float> HandleActionList(List<string> list)
 	{
 		foreach (string element in list)
 		{
-			string[] actionSplit = element.Split(':');
-			string action = actionSplit[0];
-			string argument = actionSplit[1];
+			string[] segments = element.Split(',');
 
-			switch (action.ToLowerInvariant())
+			foreach (string segment in segments)
 			{
-				case "load":
-				case "l":
-					{
-						List<string> allMaps = ListPool<string>.Shared.Rent(Directory.GetFiles(ProjectMER.MapsDir).Select(Path.GetFileNameWithoutExtension));
-						HandleMapLoading(argument, allMaps);
-						ListPool<string>.Shared.Return(allMaps);
-						continue;
-					}
+				string[] actionSplit = segment.Split(':');
+				if (actionSplit.Length < 2)
+				{
+					Logger.Error($"Invalid action segment: {segment}");
+					continue;
+				}
 
-				case "unload":
-				case "unl":
-					{
-						List<string> allMaps = ListPool<string>.Shared.Rent(MapUtils.LoadedMaps.Keys);
-						HandleMapUnloading(argument, allMaps);
-						ListPool<string>.Shared.Return(allMaps);
-						continue;
-					}
+				string action = actionSplit[0].Trim().ToLowerInvariant();
+				string argument = actionSplit[1].Trim();
 
-				case "console":
-				case "cs":
-					{
-						Server.RunCommand(argument);
-						continue;
-					}
+				switch (action)
+				{
+					case "load":
+					case "l":
+						{
+							List<string> allMaps = ListPool<string>.Shared.Rent(Directory.GetFiles(ProjectMER.MapsDir).Select(Path.GetFileNameWithoutExtension));
+							HandleMapLoading(argument, allMaps);
+							ListPool<string>.Shared.Return(allMaps);
+							break;
+						}
 
-				default:
-					{
-						Logger.Error($"Unknown action: {action}");
-						continue;
-					}
+					case "unload":
+					case "unl":
+						{
+							List<string> allMaps = ListPool<string>.Shared.Rent(MapUtils.LoadedMaps.Keys);
+							HandleMapUnloading(argument, allMaps);
+							ListPool<string>.Shared.Return(allMaps);
+							break;
+						}
+
+					case "wait":
+					case "w":
+						{
+							if (int.TryParse(argument, out int ms))
+								yield return Timing.WaitForSeconds(ms / 1000f);
+							else
+								Logger.Error($"Invalid wait duration: {argument}");
+							break;
+						}
+
+					case "console":
+					case "cs":
+						{
+							Server.RunCommand(argument);
+							break;
+						}
+
+					default:
+						{
+							Logger.Error($"Unknown action: {action}");
+							break;
+						}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Added support for Wait: action in HandleActionList()

You can now write commands like:
"Load:LczMap,Wait:1000,Load:HczMap"
This introduces a delay of 1000ms between map loads.

Refactored HandleActionList() to a coroutine using MEC
Allows sequential execution with support for delays (Timing.WaitForSeconds())