### PR TITLE
chore(release): bump version to 2026.3.16

### DIFF
--- a/ProjectMER.csproj
+++ b/ProjectMER.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.3.6" />
+    <PackageReference Include="Northwood.LabAPI" Version="1.1.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Updated dependencies to be compatible with the latest LabAPI version.

## Changes
- Updated Northwood.LabAPI to 1.1.5